### PR TITLE
Bug fix and added custom mapping

### DIFF
--- a/lilit/__init__.py
+++ b/lilit/__init__.py
@@ -92,5 +92,5 @@ For additional details on how Cobaya works, I suggest to see the [documentation]
 from .likelihood import LiLit
 
 __author__ = "Giacomo Galloni"
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __docformat__ = "numpy"

--- a/lilit/likelihood.py
+++ b/lilit/likelihood.py
@@ -27,6 +27,8 @@ class LiLit(Likelihood):
             Path to Cl file (default: None).
         nl_file (str, optional):
             Path to noise file (default: None).
+        mapping (dict, optional):
+            Dictionary of mapping between the fields in the noise file and the fields in the likelihood, used only if nl_file has .txt extension (default: None).
         experiment (str, optional):
             Name of experiment (default: None).
         nside (int, optional):
@@ -90,6 +92,8 @@ class LiLit(Likelihood):
             Cobaya vector obtained by summing cobaCOV + noiseCOV.
         nl_file (str):
             Path to noise file.
+        mapping (dict):
+            Dictionary of mapping between the fields in the noise file and the fields in the likelihood, used only if nl_file has .txt extension.
         experiment (str):
             Name of experiment.
         nside (int):
@@ -115,6 +119,7 @@ class LiLit(Likelihood):
         lmin=2,
         cl_file=None,
         nl_file=None,
+        mapping=None,
         experiment=None,
         nside=None,
         r=None,
@@ -142,6 +147,8 @@ class LiLit(Likelihood):
         self.sep = sep
         self.cl_file = cl_file
         self.nl_file = nl_file
+        if self.nl_file.endswith(".txt"):
+            self.mapping = mapping
         self.experiment = experiment
         if self.experiment is not None:
             # Check that the user has provided the nside if an experiment is used
@@ -560,9 +567,8 @@ class LiLit(Likelihood):
             # If not, load the file as a text file
             else:
                 _txt = np.loadtxt(self.nl_file)
-                _mapping = {"bb": 0}
                 # Convert the text file to a dictionary
-                res = self.txt2dict(_txt, _mapping, apply_ellfactor=True)
+                res = self.txt2dict(_txt, self.mapping, apply_ellfactor=True)
             return res
 
         print(

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setup(
         "camb",
     ],
     long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
Now it is possible to pass to LiLit a custom mapping of the nl_file (in case it is a .txt file)